### PR TITLE
Replace PatternSignatures with ScopedTypeVariables

### DIFF
--- a/examples/AIS.hs
+++ b/examples/AIS.hs
@@ -5,7 +5,7 @@
 -- for Definition and Background, see
 -- http://www.combinatorics.org/ojs/index.php/eljc/article/view/DS6
 
-{-# language PatternSignatures #-}
+{-# language ScopedTypeVariables #-}
 
 import Prelude hiding ( not, product, and, or )
 import qualified Prelude

--- a/examples/Cage.hs
+++ b/examples/Cage.hs
@@ -2,7 +2,7 @@
 -- example usage: ./dist/build/Cage/Cage 3 5 10
 -- should find the Petersen graph
 
-{-# language PatternSignatures #-}
+{-# language ScopedTypeVariables #-}
 
 import Prelude hiding ( not, product )
 import qualified Prelude

--- a/examples/Factor.hs
+++ b/examples/Factor.hs
@@ -2,7 +2,7 @@
 -- | run like this: ./test/Factor 1000000000001
 -- (takes 10 .. 20 seconds depending on your CPU)
 
-{-# language PatternSignatures #-}
+{-# language ScopedTypeVariables #-}
 
 import Prelude hiding ( not )
 

--- a/examples/HC.hs
+++ b/examples/HC.hs
@@ -2,7 +2,7 @@
 -- example usage: ./dist/build/HC/HC 8 8
 -- should find and print a solution in < 10 seconds.
 
-{-# language PatternSignatures #-}
+{-# language ScopedTypeVariables #-}
 
 import Prelude hiding ( not )
 import qualified Prelude

--- a/examples/Hidoku.hs
+++ b/examples/Hidoku.hs
@@ -9,7 +9,7 @@
 -- For discussion of a many more encoding options,
 -- see 4.2 and 4.4 of http://nbn-resolving.de/urn:nbn:de:bsz:14-qucosa-158672
 
-{-# language PatternSignatures #-}
+{-# language ScopedTypeVariables #-}
 
 import Prelude hiding ( not, product )
 import qualified Prelude

--- a/examples/Langford.hs
+++ b/examples/Langford.hs
@@ -1,7 +1,7 @@
 -- | The Langford Sequence Problem
 -- http://www.csplib.org/Problems/prob024/
 
-{-# language PatternSignatures #-}
+{-# language ScopedTypeVariables #-}
 
 import Prelude hiding ( not, product, and, or )
 import qualified Prelude

--- a/examples/Oscillator.hs
+++ b/examples/Oscillator.hs
@@ -3,7 +3,7 @@
 -- example usage: ./dist/build/Life/Life 3 9 9 20
 -- arguments are: period, width, height, number of life start cells
 
-{-# language PatternSignatures #-}
+{-# language ScopedTypeVariables #-}
 {-# language FlexibleContexts #-}
 
 import Prelude hiding ( not, or, and )

--- a/examples/PP.hs
+++ b/examples/PP.hs
@@ -1,7 +1,7 @@
 -- | find incidence matrix of projective plane of given order
 -- example usage: ./dist/build/PP/PP 2
 
-{-# language PatternSignatures #-}
+{-# language ScopedTypeVariables #-}
 {-# language FlexibleContexts #-}
 
 import Prelude hiding ( not, and, or )

--- a/examples/Pigeon.hs
+++ b/examples/Pigeon.hs
@@ -1,7 +1,7 @@
 -- | Simple Pigoenhole benchmark:
 -- put  p  pigeons in (p-1) holes.
 
-{-# language PatternSignatures #-}
+{-# language ScopedTypeVariables #-}
 
 import Prelude hiding ( not, product )
 import qualified Prelude

--- a/examples/RFC.hs
+++ b/examples/RFC.hs
@@ -1,7 +1,7 @@
 -- rectangle free colourings of grids
 -- see http://www.cs.umd.edu/~gasarch/papers/grid.pdf
 
-{-# language PatternSignatures #-}
+{-# language ScopedTypeVariables #-}
 {-# language NoMonomorphismRestriction #-}
 
 import Prelude hiding ( not, and, or, product )

--- a/examples/Ramsey.hs
+++ b/examples/Ramsey.hs
@@ -3,7 +3,7 @@
 -- last number is size of graph,
 -- earlier numbers are sizes of forbidden cliques
 
-{-# language PatternSignatures #-}
+{-# language ScopedTypeVariables #-}
 {-# language FlexibleContexts #-}
 
 import Prelude hiding ( not, and, or, product )

--- a/examples/RamseyFM.hs
+++ b/examples/RamseyFM.hs
@@ -3,7 +3,7 @@
 -- last number is size of graph,
 -- earlier numbers are sizes of forbidden cliques
 
-{-# language PatternSignatures #-}
+{-# language ScopedTypeVariables #-}
 
 import Prelude hiding ( not, and, or, product )
 import qualified Prelude

--- a/examples/Spaceship.hs
+++ b/examples/Spaceship.hs
@@ -6,7 +6,7 @@
 -- ./Spaceship 1 1 4 6     -- glider
 -- ./Spaceship 0 2 4 7 9 9 -- Conway's lightweight spaceship
 
-{-# language PatternSignatures #-}
+{-# language ScopedTypeVariables #-}
 {-# language FlexibleContexts #-}
 
 import Prelude hiding ( not, or, and )

--- a/examples/Sudoku.hs
+++ b/examples/Sudoku.hs
@@ -3,7 +3,7 @@
 -- argument n: board is (n^2)x(n^2),
 -- so standard Sudoku is for n=3
 
-{-# language PatternSignatures #-}
+{-# language ScopedTypeVariables #-}
 
 import Prelude hiding ( not, product )
 import qualified Prelude

--- a/examples/VC.hs
+++ b/examples/VC.hs
@@ -3,7 +3,7 @@
 -- (that is, if you put knights there, they control the full board)
 -- example: VC 8 12
 
-{-# language PatternSignatures #-}
+{-# language ScopedTypeVariables #-}
 
 import Prelude hiding ( not )
 

--- a/examples/Waerden.hs
+++ b/examples/Waerden.hs
@@ -1,7 +1,7 @@
 -- | find van der Warden Colourings
 -- (avoiding monochromatic arithmetic sequences)
 
-{-# language PatternSignatures #-}
+{-# language ScopedTypeVariables #-}
 
 import Prelude hiding ( not, and, or, product )
 import qualified Prelude

--- a/examples/WaerdenGlucose.hs
+++ b/examples/WaerdenGlucose.hs
@@ -1,7 +1,7 @@
 -- | find van der Warden Colourings
 -- (avoiding monochromatic arithmetic sequences)
 
-{-# language PatternSignatures #-}
+{-# language ScopedTypeVariables #-}
 
 import Prelude hiding ( not, and, or, product )
 import qualified Prelude

--- a/src/Satchmo/SAT/CNF.hs
+++ b/src/Satchmo/SAT/CNF.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE DoAndIfThenElse #-}
-{-# LANGUAGE PatternSignatures #-}
+{-# LANGUAGE ScopedTypeVaribles #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 

--- a/src/Satchmo/SAT/External.hs
+++ b/src/Satchmo/SAT/External.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE DoAndIfThenElse #-}
-{-# LANGUAGE PatternSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# language TemplateHaskell #-}
 

--- a/src/Satchmo/SAT/Mini.hs
+++ b/src/Satchmo/SAT/Mini.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE DoAndIfThenElse #-}
-{-# LANGUAGE PatternSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
 

--- a/src/Satchmo/Unary/Op/Common.hs
+++ b/src/Satchmo/Unary/Op/Common.hs
@@ -1,5 +1,5 @@
 {-# language NoMonomorphismRestriction #-}
-{-# language PatternSignatures #-}
+{-# language ScopedTypeVariables #-}
 
 module Satchmo.Unary.Op.Common 
        


### PR DESCRIPTION
`PatternSignatures` is deprecated in GHC 6.10.1 released in 2008.

I think it is okay to drop support for GHCs older than that.