### PR TITLE
Fix compilation error with mtl >=2.3

### DIFF
--- a/src/Satchmo/Boolean/Data.hs
+++ b/src/Satchmo/Boolean/Data.hs
@@ -31,6 +31,7 @@ import Data.Array
 import Data.Maybe ( fromJust )
 import Data.List ( partition )
 
+import Control.Monad
 import Control.Monad.Reader
 
 import GHC.Generics (Generic)

--- a/src/Satchmo/MonadSAT.hs
+++ b/src/Satchmo/MonadSAT.hs
@@ -23,7 +23,9 @@ import Satchmo.Code
 import Control.Applicative
 import Control.Monad.Trans (lift)
 import Control.Monad.Cont  (ContT)
+#if !MIN_VERSION_mtl(2,3,0)
 import Control.Monad.List  (ListT)
+#endif
 import Control.Monad.Reader (ReaderT)
 import Control.Monad.Fix ( MonadFix )
 import qualified Control.Monad.State  as Lazy (StateT)
@@ -63,12 +65,16 @@ data Header =
 -- MonadSAT liftings for standard monad transformers
 -- -------------------------------------------------------
 
+#if !MIN_VERSION_mtl(2,3,0)
+
 instance (Monad m, MonadSAT m) => MonadSAT (ListT m) where
   fresh = lift fresh
   fresh_forall = lift fresh_forall
   emit  = lift . emit
   -- emitW = (lift.) . emitW
   note = lift . note
+
+#endif
 
 instance (Monad m, MonadSAT m) => MonadSAT (ReaderT r m) where
   fresh = lift fresh

--- a/src/Satchmo/SAT/External.hs
+++ b/src/Satchmo/SAT/External.hs
@@ -25,6 +25,7 @@ import Satchmo.Boolean hiding ( not )
 import Satchmo.Code
 -- import Satchmo.MonadSAT
 
+import Control.Monad
 import Control.Monad.Reader
 import Control.Monad.State
 -- import Control.Monad.IO.Class

--- a/src/Satchmo/SAT/Tmpfile.hs
+++ b/src/Satchmo/SAT/Tmpfile.hs
@@ -20,6 +20,8 @@ import Satchmo.Boolean.Data
 import Satchmo.MonadSAT
 
 import Control.Exception
+import Control.Monad
+import Control.Monad.Fix
 import Control.Monad.RWS.Strict
 import Control.Applicative
 import qualified  Data.Set as Set


### PR DESCRIPTION
`mtl-2.3.0` removed the `Control.Monad.List` module and some re-exports of `Control.Monad` and `Control.Monad.Fix` from its modules.